### PR TITLE
update: submodule dot-graph with key changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,9 +95,11 @@ With `dot-viewer`, users may
 
 Key | Command | Actions
 --- | --- | ---
-`q` | | quit `dot-viewer`
- &nbsp; | `:help<CR>` | show help
+&nbsp; | `:q<C-R>` | quit `dot-viewer`
+&nbsp; | `:help<CR>` | show help
 `esc` | &nbsp; | go back to the main screen
+
+**Hit `esc` to go back to Normal mode whenever you are unsure of what you are doing...**
 
 ### Mode Switches
 

--- a/src/viewer/app.rs
+++ b/src/viewer/app.rs
@@ -179,6 +179,10 @@ impl App {
                 self.set_popup_mode(PopupMode::Tree);
                 Ok(Success::default())
             }
+            Command::Quit => {
+                self.quit = true;
+                Ok(Success::default())
+            }
             Command::NoMatch => {
                 self.set_normal_mode();
 

--- a/src/viewer/app.rs
+++ b/src/viewer/app.rs
@@ -10,7 +10,7 @@ use crate::viewer::{
 
 use std::fs;
 
-use dot_graph::{parser, Graph};
+use dot_graph::prelude::*;
 
 use crossterm::event::KeyCode;
 
@@ -53,7 +53,7 @@ impl App {
 
         let result: DotViewerResult<Success> = Ok(Success::default());
 
-        let graph = parser::parse(path)?;
+        let graph = parser::parse_from_file(path)?;
 
         let view = View::new(graph.id().clone(), graph)?;
         let tabs = Tabs::from_iter(vec![view]);

--- a/src/viewer/command.rs
+++ b/src/viewer/command.rs
@@ -9,6 +9,7 @@ pub(crate) enum Command {
     Filter,
     Help,
     Subgraph,
+    Quit,
     NoMatch,
 }
 
@@ -32,7 +33,7 @@ pub(crate) struct CommandTrie {
     pub(crate) _trie_arg: Trie,
 }
 
-fn subcommands() -> [ClapCommand; 6] {
+fn subcommands() -> [ClapCommand; 7] {
     [
         ClapCommand::new("neighbors")
             .arg(Arg::new("depth").value_parser(clap::value_parser!(usize))),
@@ -41,6 +42,7 @@ fn subcommands() -> [ClapCommand; 6] {
         ClapCommand::new("filter"),
         ClapCommand::new("help"),
         ClapCommand::new("subgraph"),
+        ClapCommand::new("q"),
     ]
 }
 
@@ -79,6 +81,7 @@ impl Command {
                 Some(("filter", _)) => Self::Filter,
                 Some(("help", _)) => Self::Help,
                 Some(("subgraph", _)) => Self::Subgraph,
+                Some(("q", _)) => Self::Quit,
                 _ => unreachable!(),
             },
             Err(_) => Self::NoMatch,

--- a/src/viewer/error.rs
+++ b/src/viewer/error.rs
@@ -1,4 +1,4 @@
-use dot_graph::DotGraphError;
+use dot_graph::prelude::*;
 
 use crossterm::event::KeyCode;
 use thiserror::Error;

--- a/src/viewer/keybindings.rs
+++ b/src/viewer/keybindings.rs
@@ -20,6 +20,8 @@ impl App {
             KeyCode::Esc => self.esc().map(|_| Success::default()),
             KeyCode::Tab => self.tab().map(|_| Success::default()),
             KeyCode::BackTab => self.backtab().map(|_| Success::default()),
+            KeyCode::Up => self.up().map(|_| Success::default()),
+            KeyCode::Down => self.down().map(|_| Success::default()),
             KeyCode::Right => self.right().map(|_| Success::default()),
             KeyCode::Left => self.left().map(|_| Success::default()),
             _ => Ok(Success::default()),

--- a/src/viewer/keybindings.rs
+++ b/src/viewer/keybindings.rs
@@ -47,7 +47,6 @@ impl App {
 
     fn char_normal(&mut self, c: char) -> DotViewerResult<()> {
         match c {
-            'q' => self.quit = true,
             '/' => self.set_search_mode(SearchMode::Fuzzy),
             'r' => self.set_search_mode(SearchMode::Regex),
             ':' => self.set_command_mode(),
@@ -88,10 +87,6 @@ impl App {
 
     fn char_tree(&mut self, c: char) -> DotViewerResult<()> {
         match c {
-            'q' => {
-                self.quit = true;
-                Ok(())
-            }
             'h' => self.left(),
             'j' => self.down(),
             'k' => self.up(),
@@ -102,10 +97,6 @@ impl App {
 
     fn char_help(&mut self, c: char) -> DotViewerResult<()> {
         match c {
-            'q' => {
-                self.quit = true;
-                Ok(())
-            }
             'j' => self.down(),
             'k' => self.up(),
             _ => Err(DotViewerError::KeyError(KeyCode::Char(c))),

--- a/src/viewer/utils/tree.rs
+++ b/src/viewer/utils/tree.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code)]
 
-use dot_graph::Graph;
+use dot_graph::prelude::*;
 
 use tui_tree_widget::{TreeItem, TreeState};
 

--- a/src/viewer/view.rs
+++ b/src/viewer/view.rs
@@ -3,7 +3,7 @@ use crate::viewer::{
     utils::{List, Tree, Trie},
 };
 
-use dot_graph::Graph;
+use dot_graph::prelude::*;
 
 use fuzzy_matcher::{skim::SkimMatcherV2, FuzzyMatcher};
 use rayon::prelude::*;


### PR DESCRIPTION
### Submodule

`dot-graph` [has been improved](https://github.com/furiosa-ai/dot-graph/pull/11) such that it can parse and export a broader range of directed dot graphs.

### Key Changes

#### A. Quit keybinding to command

Previously, `q` shortcut was used to quit the application. It makes it easy for users to unintentionally quit from `dot-viewer`.

Now, users may quit using `:q<C-R>`, just like in Vim.

#### B. Arrow key supports

Users from non-Vim backgrounds may traverse using arrow keys instead of `h/j/k/l`s.

